### PR TITLE
[Refactor] 커버링 인덱스를 활용한 피드 조회 쿼리 성능 개선

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedMediaRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedMediaRepository.java
@@ -4,6 +4,9 @@ import com.samsamhajo.deepground.feed.feed.entity.FeedMedia;
 import com.samsamhajo.deepground.media.MediaErrorCode;
 import com.samsamhajo.deepground.media.MediaException;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,4 +25,9 @@ public interface FeedMediaRepository extends JpaRepository<FeedMedia, Long> {
         return findById(feedMediaId)
                 .orElseThrow(() -> new MediaException(MediaErrorCode.MEDIA_NOT_FOUND,feedMediaId));
     }
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE FeedMedia fm SET fm.deleted = true WHERE fm.feed.id = :feedId")
+    void softDeleteAllByFeedId(@Param("feedId") Long feedId);
 }
+

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedMediaRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedMediaRepository.java
@@ -19,8 +19,6 @@ public interface FeedMediaRepository extends JpaRepository<FeedMedia, Long> {
 
     List<FeedMedia> findAllByFeedId(Long feedId);
     
-    void deleteAllByFeedId(Long feedId);
-    
     default FeedMedia getById(Long feedMediaId){
         return findById(feedMediaId)
                 .orElseThrow(() -> new MediaException(MediaErrorCode.MEDIA_NOT_FOUND,feedMediaId));

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedRepositoryImpl.java
@@ -21,7 +21,7 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     public Slice<FetchFeedResponse> findFeeds(Pageable pageable) {
 
         List<Long> ids = em.createQuery(
-                        "SELECT f.id FROM Feed f ORDER BY f.createdAt DESC", Long.class)
+                        "select f.id from Feed f order by f.createdAt desc", Long.class)
                 .setFirstResult((int) pageable.getOffset())
                 .setMaxResults(pageable.getPageSize() + 1)
                 .getResultList();

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedRepositoryImpl.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedRepositoryImpl.java
@@ -20,21 +20,35 @@ public class FeedRepositoryImpl implements FeedRepositoryCustom {
     @Override
     public Slice<FetchFeedResponse> findFeeds(Pageable pageable) {
 
-        List<FetchFeedResponse> feeds = em.createQuery("select new com.samsamhajo.deepground.feed.feed.model.v2.FetchFeedResponse" +
-                        "(m.publicId , mp.profilePublicId , f.id, m.nickname, f.content, f.likeCount, f.commentCount," +
-                        "f.sharedCount, mp.profileImage, f.createdAt)" +
-                        "from Feed f " +
-                        "join f.member m " +
-                        "left join m.memberProfile mp", FetchFeedResponse.class)
+        List<Long> ids = em.createQuery(
+                        "SELECT f.id FROM Feed f ORDER BY f.createdAt DESC", Long.class)
                 .setFirstResult((int) pageable.getOffset())
-                .setMaxResults(pageable.getPageSize()+1)
+                .setMaxResults(pageable.getPageSize() + 1)
                 .getResultList();
 
+        if (ids.isEmpty()) {
+            return new SliceImpl<>(List.of(), pageable, false);
+        }
+
         boolean hasNext = false;
-        if (feeds.size() > pageable.getPageSize()) {
-            feeds.remove(pageable.getPageSize());
+        if (ids.size() > pageable.getPageSize()) {
+            ids.remove(pageable.getPageSize());
             hasNext = true;
         }
+
+        List<FetchFeedResponse> feeds = em.createQuery("select new com.samsamhajo.deepground.feed.feed.model.v2.FetchFeedResponse " +
+                                "(m.publicId , mp.profilePublicId , f.id, m.nickname, f.content, f.likeCount, f.commentCount," +
+                                "f.sharedCount, mp.profileImage, f.createdAt)" +
+                                "from Feed f " +
+                                "join f.member m " +
+                                "left join m.memberProfile mp " +
+                                "where f.id in :ids " +
+                                "order by f.createdAt desc",
+                        FetchFeedResponse.class)
+                .setParameter("ids", ids)
+                .getResultList();
+
+
         return new SliceImpl<>(feeds,pageable,hasNext);
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -48,7 +48,9 @@ public class FeedMediaService {
     @Transactional
     public void deleteAllByFeedId(Long feedId) {
         // DB에서 삭제 (JPA Query Method 사용)
-        feedMediaRepository.deleteAllByFeedId(feedId);
+        List<FeedMedia> mediaList = feedMediaRepository.findAllByFeedId(feedId);
+
+        mediaList.forEach(FeedMedia::softDelete);
     }
 
     public void updateFeedMedia(Feed feed, FeedUpdateRequest request) {

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -47,10 +47,7 @@ public class FeedMediaService {
     
     @Transactional
     public void deleteAllByFeedId(Long feedId) {
-        // DB에서 삭제 (JPA Query Method 사용)
-        List<FeedMedia> mediaList = feedMediaRepository.findAllByFeedId(feedId);
-
-        mediaList.forEach(FeedMedia::softDelete);
+        feedMediaRepository.softDeleteAllByFeedId(feedId);
     }
 
     public void updateFeedMedia(Feed feed, FeedUpdateRequest request) {

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -155,9 +155,12 @@ public class FeedService {
     @Transactional
     public void deleteFeed(Long feedId) {
 
+        Feed feed = feedRepository.getById(feedId);
+
         deleteRelatedEntities(feedId);
 
-        feedRepository.deleteById(feedId);
+        feed.softDelete();
+
     }
 
     private void deleteRelatedEntities(Long feedId) {

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaServiceTest.java
@@ -135,7 +135,7 @@ class FeedMediaServiceTest {
 
             // then
             verify(s3Uploader).upload(any(MultipartFile.class), eq("feed-media"));
-            verify(feedMediaRepository).deleteAllByFeedId(1L);
+            verify(feedMediaRepository).softDeleteAllByFeedId(1L);
             verify(feedMediaRepository).saveAll(anyList());
         }
     }


### PR DESCRIPTION
## 📌 개요
- 현재 페이징 조회 시 데이터 순서가 보장되지 않아 추후 데이터 일관성 및 중복/누락을 방지하기 위해 작성 순으로 내림차순 정렬 및 커버링 인덱스 활용을 위한 쿼리문 작성

## 🛠️ 작업 내용
- [x] `hardDelete` -> `softDelete` 로 변경
- [x] 커버링 인덱스 로직 적용: Pk인 id 만을 조회하는 쿼리를 분리하여 불필요한 데이터 접근 최소화
- [x] 복합 인덱스 생성:`idx_feed_is_deleted_and_created_at`(is_deleted, created_at DESC) 

### 성능 개선 결과
- 기존 쿼리문에서 정렬 시 인덱스를 안탐 
<img width="629" height="761" alt="image" src="https://github.com/user-attachments/assets/0c9c5296-f5c8-4f9d-9a4e-6b811488d79f" />
- 쿼리 로직 변경 (인덱스 생성 전)
<img width="1123" height="836" alt="쿼리문 뷰 인덱스x" src="https://github.com/user-attachments/assets/5bdf7871-4cd5-440b-84ad-24f0ea2fb697" />
- 인덱스 생성 후 커버링 인덱스 사용 시
<img width="1107" height="837" alt="created index + 쿼리문 뷰" src="https://github.com/user-attachments/assets/b30ea64a-d474-4b23-90ac-870e3b44d6a6" />

## 📌 차후 계획 (Optional)
- 연관 관계 엔티티 조회 최적화
- 캐싱 도입: 반복적인 조회 요청에 대해 Redis 등을 활용한 성능 개선

## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인
* (구현한 로직 검증을 위해 테스트한 내용을 설명해주세요)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Faster, more reliable feed loading via a two-step retrieval that preserves ordering, handles empty pages, and fixes pagination flags.
* **Improvements**
  * Deletion flow updated to soft-delete feeds (preserving records for auditing/recovery).
* **New Features**
  * Bulk soft-delete for feed media to simplify cleanup while retaining recoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

close #1