### PR TITLE
{Refactor} Redis 기반 피드 목록 조회 캐싱 구현

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/handler/FeedCacheHandler.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/handler/FeedCacheHandler.java
@@ -3,23 +3,31 @@ package com.samsamhajo.deepground.feed.feed.handler;
 import com.samsamhajo.deepground.feed.feed.model.FeedCreateEvent;
 import com.samsamhajo.deepground.feed.feed.model.FetchFeedResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
+import static org.springframework.transaction.event.TransactionPhase.AFTER_COMMIT;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class FeedCacheHandler {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    @TransactionalEventListener(phase =  TransactionPhase.AFTER_COMMIT)
-    public void handleFeedCreatedEvent(FeedCreateEvent event){
-        FetchFeedResponse cacheDto = FetchFeedResponse.forCache(event.feed(), event.member(), event.mediaUrls());
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void handleFeedCreatedEvent(FeedCreateEvent event) {
+        try {
+            String key = "feed:recent:20";
+            redisTemplate.opsForList().leftPush(key, event.fetchFeedResponse());
+            redisTemplate.opsForList().trim(key, 0, 19);
 
-        String key = "feed:recent:20";
-        redisTemplate.opsForList().leftPush(key, cacheDto);
-        redisTemplate.opsForList().trim(key,0,19);
+            log.info("Redis 캐시 적재 성공");
+        } catch (Exception e) {
+            log.error("Redis 저장 실패 원인:", e);
+        }
     }
 }
+

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/handler/FeedCacheHandler.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/handler/FeedCacheHandler.java
@@ -1,0 +1,25 @@
+package com.samsamhajo.deepground.feed.feed.handler;
+
+import com.samsamhajo.deepground.feed.feed.model.FeedCreateEvent;
+import com.samsamhajo.deepground.feed.feed.model.FetchFeedResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class FeedCacheHandler {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    @TransactionalEventListener(phase =  TransactionPhase.AFTER_COMMIT)
+    public void handleFeedCreatedEvent(FeedCreateEvent event){
+        FetchFeedResponse cacheDto = FetchFeedResponse.forCache(event.feed(), event.member(), event.mediaUrls());
+
+        String key = "feed:recent:20";
+        redisTemplate.opsForList().leftPush(key, cacheDto);
+        redisTemplate.opsForList().trim(key,0,19);
+    }
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/model/FeedCreateEvent.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/model/FeedCreateEvent.java
@@ -1,0 +1,11 @@
+package com.samsamhajo.deepground.feed.feed.model;
+
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.member.entity.Member;
+
+import java.util.List;
+
+public record FeedCreateEvent(Feed feed,
+                              Member member,
+                              List<String> mediaUrls) {
+}

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/model/FeedCreateEvent.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/model/FeedCreateEvent.java
@@ -1,11 +1,4 @@
 package com.samsamhajo.deepground.feed.feed.model;
 
-import com.samsamhajo.deepground.feed.feed.entity.Feed;
-import com.samsamhajo.deepground.member.entity.Member;
-
-import java.util.List;
-
-public record FeedCreateEvent(Feed feed,
-                              Member member,
-                              List<String> mediaUrls) {
+public record FeedCreateEvent(FetchFeedResponse fetchFeedResponse) {
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/model/FetchFeedResponse.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/model/FetchFeedResponse.java
@@ -1,5 +1,7 @@
 package com.samsamhajo.deepground.feed.feed.model;
 
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
+import com.samsamhajo.deepground.member.entity.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -30,7 +32,7 @@ public class FetchFeedResponse {
 
     private FetchFeedResponse(UUID publicId, UUID profilePublicId, Long feedId, String memberName,
                               String content, int likeCount, int commentCount, int shareCount,
-                              String profileImageUrl, LocalDateTime createdAt){
+                              String profileImageUrl, LocalDateTime createdAt) {
         this.publicId = publicId;
         this.profilePublicId = profilePublicId;
         this.feedId = feedId;
@@ -44,8 +46,8 @@ public class FetchFeedResponse {
     }
 
     private FetchFeedResponse(UUID publicId, UUID profilePublicId, Long feedId, String memberName,
-                              String content, int likeCount, int commentCount, int shareCount,boolean isLiked,
-                              String profileImageUrl, LocalDateTime createdAt, List<String> mediaUrls){
+                              String content, int likeCount, int commentCount, int shareCount, boolean isLiked,
+                              String profileImageUrl, LocalDateTime createdAt, List<String> mediaUrls) {
         this.publicId = publicId;
         this.profilePublicId = profilePublicId;
         this.feedId = feedId;
@@ -67,6 +69,23 @@ public class FetchFeedResponse {
                 publicId, profilePublicId, feedId, memberName, content,
                 likeCount, commentCount, shareCount, isLiked,
                 profileImageUrl, createdAt, mediaUrls
+        );
+    }
+
+    public static FetchFeedResponse forCache(Feed feed, Member member, List<String> mediaUrls) {
+        return new FetchFeedResponse(
+                feed.getMember().getPublicId(),
+                member.getMemberProfile().getProfilePublicId(),
+                feed.getId(),
+                member.getNickname(),
+                feed.getContent(),
+                0, // 초기 좋아요 수
+                0, // 초기 댓글 수
+                0, // 초기 공유 수
+                false,
+                member.getMemberProfile().getProfileImage(),
+                feed.getCreatedAt(),
+                mediaUrls
         );
     }
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.feed.feed.repository;
 
+import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.entity.FeedLike;
 import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
 import com.samsamhajo.deepground.feed.feed.exception.FeedException;
@@ -23,4 +24,6 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
     void deleteAllByFeedId(Long feedId);
 
     void deleteByFeedIdAndMemberId(Long feedId, Long memberId);
+
+    List<Long> feed(Feed feed);
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/repository/FeedLikeRepository.java
@@ -25,5 +25,4 @@ public interface FeedLikeRepository extends JpaRepository<FeedLike, Long> {
 
     void deleteByFeedIdAndMemberId(Long feedId, Long memberId);
 
-    List<Long> feed(Feed feed);
 }

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeSyncService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeSyncService.java
@@ -1,11 +1,14 @@
 package com.samsamhajo.deepground.feed.feed.service;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
@@ -21,15 +24,31 @@ public class FeedLikeSyncService {
     private final RedisTemplate<String, Object> redisTemplate;
     private final FeedRepository feedRepository;
 
+    private Set<Object> getAndClearDirtySet(String key) {
+        String script =
+                "local members = redis.call('SMEMBERS', KEYS[1]) " +
+                        "if #members > 0 then " +
+                        "    redis.call('DEL', KEYS[1]) " +
+                        "end " +
+                        "return members";
+
+        List<Object> result = redisTemplate.execute(
+                new DefaultRedisScript<>(script, List.class),
+                Collections.singletonList(key)
+        );
+
+        if (result == null || result.isEmpty()) {
+            return Collections.emptySet();
+        }
+        return new HashSet<>(result);
+    }
+
     @Transactional
     public void syncFeedLikesToDatabase() {
         String key = "feed:likes:dirty";
 
-        Set<Object> dirtyFeedIds = redisTemplate.opsForSet().members(key);
-
-        if(dirtyFeedIds == null || dirtyFeedIds.isEmpty()) return;
-
-        redisTemplate.delete(key);
+        Set<Object> dirtyFeedIds = getAndClearDirtySet(key);
+        if (dirtyFeedIds.isEmpty()) return;
 
         for (Object idObj : dirtyFeedIds) {
             try{

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeSyncService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeSyncService.java
@@ -23,8 +23,13 @@ public class FeedLikeSyncService {
 
     @Transactional
     public void syncFeedLikesToDatabase() {
-        List<Object> dirtyFeedIds = redisTemplate.opsForSet().pop("feed:likes:dirty", 1000);
-        if (dirtyFeedIds == null || dirtyFeedIds.isEmpty()) return;
+        String key = "feed:likes:dirty";
+
+        Set<Object> dirtyFeedIds = redisTemplate.opsForSet().members(key);
+
+        if(dirtyFeedIds == null || dirtyFeedIds.isEmpty()) return;
+
+        redisTemplate.delete(key);
 
         for (Object idObj : dirtyFeedIds) {
             try{

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedMediaService.java
@@ -27,8 +27,8 @@ public class FeedMediaService {
     private final S3Uploader s3Uploader;
 
     @Transactional
-    public void createFeedMedia(Feed feed, List<MultipartFile> images) {
-        if (CollectionUtils.isEmpty(images)) return;
+    public List<String> createFeedMedia(Feed feed, List<MultipartFile> images) {
+        if (CollectionUtils.isEmpty(images)) return List.of();
 
         List<FeedMedia> mediaEntities = images.stream()
                 .map(image -> {
@@ -38,7 +38,11 @@ public class FeedMediaService {
                 })
                 .toList();
 
-        feedMediaRepository.saveAll(mediaEntities);
+        List<FeedMedia> savedMedia = feedMediaRepository.saveAll(mediaEntities);
+
+        return savedMedia.stream()
+                .map(FeedMedia::getMediaUrl)
+                .toList();
     }
 
     public List<FeedMedia> findAllByFeed(Feed feed) {

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -12,7 +12,6 @@ import com.samsamhajo.deepground.feed.feed.repository.FeedMediaRepository;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
 import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentService;
 import com.samsamhajo.deepground.member.entity.Member;
-import com.samsamhajo.deepground.member.entity.MemberProfile;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -54,8 +53,9 @@ public class FeedService {
         feedRepository.save(feed);
 
         List<String> savedUrls = saveFeedMedia(request, feed);
+        FetchFeedResponse cacheDto = FetchFeedResponse.forCache(feed, member, savedUrls);
 
-        eventPublisher.publishEvent(new FeedCreateEvent(feed,member,savedUrls));
+        eventPublisher.publishEvent(new FeedCreateEvent(cacheDto));
 
         return feed;
     }
@@ -114,26 +114,36 @@ public class FeedService {
         List<FetchFeedResponse> content;
         boolean hasNext;
 
-        if(pageable.getPageNumber() == 0){
-            content = fetchFromRedis();
+        if (pageable.getPageNumber() == 0) {
+            List<FetchFeedResponse> cachedData = fetchFromRedis();
 
-            if(content.isEmpty()){
+            if (!cachedData.isEmpty()) {
+                int pageSize = pageable.getPageSize();
+
+                if (cachedData.size() > pageSize) {
+                    content = new ArrayList<>(cachedData.subList(0, pageSize));
+                    hasNext = true;
+                }
+                else {
+                    content = cachedData;
+                    hasNext = (cachedData.size() >= pageSize);
+                }
+            } else {
                 Slice<FetchFeedResponse> slice = feedRepository.findFeeds(pageable);
                 content = slice.getContent();
                 hasNext = slice.hasNext();
-            } else{
-                hasNext = true;
             }
         } else {
             Slice<FetchFeedResponse> slice = feedRepository.findFeeds(pageable);
             content = slice.getContent();
             hasNext = slice.hasNext();
         }
-
         enrichFeeds(content, memberId);
 
         return FetchFeedsResponse.of(new SliceImpl<>(content, pageable, hasNext));
     }
+
+
 
     private List<FetchFeedResponse> fetchFromRedis(){
         try {

--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -14,9 +14,13 @@ import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentService;
 import com.samsamhajo.deepground.member.entity.Member;
 import com.samsamhajo.deepground.member.entity.MemberProfile;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -24,6 +28,7 @@ import org.springframework.util.StringUtils;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -35,6 +40,8 @@ public class FeedService {
     private final FeedLikeService feedLikeService;
     private final FeedMediaRepository feedMediaRepository;
     private final FeedLikeRepository feedLikeRepository;
+    private final ApplicationEventPublisher eventPublisher;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     @Transactional
     public Feed createFeed(FeedCreateRequest request, Member member) {
@@ -46,7 +53,9 @@ public class FeedService {
 
         feedRepository.save(feed);
 
-        saveFeedMedia(request, feed);
+        List<String> savedUrls = saveFeedMedia(request, feed);
+
+        eventPublisher.publishEvent(new FeedCreateEvent(feed,member,savedUrls));
 
         return feed;
     }
@@ -102,30 +111,61 @@ public class FeedService {
 
     public FetchFeedsResponse getFeeds(Pageable pageable, Long memberId) {
 
-        Slice<FetchFeedResponse> feedSlice = feedRepository.findFeeds(pageable);
-        List<FetchFeedResponse> feeds = feedSlice.getContent();
+        List<FetchFeedResponse> content;
+        boolean hasNext;
 
-        List<Long> feedIds = feeds.stream().map(FetchFeedResponse::getFeedId).toList();
+        if(pageable.getPageNumber() == 0){
+            content = fetchFromRedis();
 
-        Map<Long,List<String>> mediaMap = feedMediaRepository.findByFeedIdIn(feedIds)
-                .stream()
-                .collect(Collectors.groupingBy(
-                        fm -> fm.getFeed().getId(),
-                        Collectors.mapping(FeedMedia::getMediaUrl, Collectors.toList())
-                ));
-
-        Set<Long> likedFeedIdSet = new HashSet<>();
-        if (memberId != null) {
-            List<Long> likes = feedLikeRepository.findLikedFeedIds(memberId, feedIds);
-            likedFeedIdSet.addAll(likes);
+            if(content.isEmpty()){
+                Slice<FetchFeedResponse> slice = feedRepository.findFeeds(pageable);
+                content = slice.getContent();
+                hasNext = slice.hasNext();
+            } else{
+                hasNext = true;
+            }
+        } else {
+            Slice<FetchFeedResponse> slice = feedRepository.findFeeds(pageable);
+            content = slice.getContent();
+            hasNext = slice.hasNext();
         }
 
-        feeds.forEach(f -> {
-            f.setMediaUrls(mediaMap.getOrDefault(f.getFeedId(), List.of()));
-            f.setLiked(likedFeedIdSet.contains(f.getFeedId()));
-        });
+        enrichFeeds(content, memberId);
 
-        return FetchFeedsResponse.of(feedSlice);
+        return FetchFeedsResponse.of(new SliceImpl<>(content, pageable, hasNext));
+    }
+
+    private List<FetchFeedResponse> fetchFromRedis(){
+        try {
+            List<Object> cachedData = redisTemplate.opsForList().range("feed:recent:20", 0, -1);
+
+            if (cachedData == null || cachedData.isEmpty()) {
+                return List.of();
+            }
+
+            return cachedData.stream()
+                    .map(obj -> (FetchFeedResponse) obj)
+                    .toList();
+        } catch (Exception e) {
+            log.error("Redis로부터 피드 캐시를 가져오는 중 에러 발생: {}",e.getMessage());
+            return List.of();
+        }
+    }
+
+    private void enrichFeeds(List<FetchFeedResponse> feeds, Long memberId) {
+        if(feeds.isEmpty() || memberId == null){
+            return;
+        }
+        List<Long> feedIds = feeds.stream()
+                .map(FetchFeedResponse::getFeedId)
+                .toList();
+
+        List<Long> likedFeedIds = feedLikeRepository.findLikedFeedIds(memberId,feedIds);
+        Set<Long> likedFeedIdSet = new HashSet<>(likedFeedIds);
+
+        feeds.forEach(feed -> {
+            feed.setLiked(likedFeedIdSet.contains(feed.getFeedId()));
+        });
     }
 
     public FetchFeedSummariesResponse getFeedSummariesByMemberId(Pageable pageable, Long memberId) {
@@ -148,8 +188,8 @@ public class FeedService {
     }
 
 
-    private void saveFeedMedia(FeedCreateRequest request, Feed feed) {
-        feedMediaService.createFeedMedia(feed, request.getImages());
+    private List<String> saveFeedMedia(FeedCreateRequest request, Feed feed) {
+        return feedMediaService.createFeedMedia(feed, request.getImages());
     }
 
     @Transactional

--- a/src/main/java/com/samsamhajo/deepground/global/config/RedisConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/RedisConfig.java
@@ -17,6 +17,8 @@ public class RedisConfig {
             RedisConnectionFactory connectionFactory,
             ObjectMapper objectMapper
     ) {
+        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         objectMapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeServiceConcurrencyTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedLikeServiceConcurrencyTest.java
@@ -7,8 +7,10 @@ import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
 import com.samsamhajo.deepground.global.config.S3Config;
 import com.samsamhajo.deepground.global.upload.S3Uploader;
 import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.entity.MemberProfile;
 import com.samsamhajo.deepground.member.entity.Role;
 import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.member.repository.ProfileRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +41,7 @@ public class FeedLikeServiceConcurrencyTest {
     @Autowired private FeedLikeSyncService feedLikeSyncService;
     @Autowired private FeedLikeScheduler feedLikeScheduler;
     @Autowired private FeedLikeRepository feedLikeRepository;
+    @Autowired private ProfileRepository profileRepository;
 
     @MockBean protected S3Config s3Config;
     @MockBean protected S3Uploader s3Uploader;
@@ -67,6 +70,16 @@ public class FeedLikeServiceConcurrencyTest {
             Member member = Member.createLocalMember("test" + i + "@example.com", "password123", "tester" + i);
             member.verify();
             member.updateRole(Role.ROLE_USER);
+            memberRepository.save(member);
+            MemberProfile profile = MemberProfile.create(
+                    "default_image.png",
+                    member,
+                    "intro", "job", "company", "city", "edu",
+                    new ArrayList<>(),
+                    "git", "link", "web", "twit"
+            );
+            profileRepository.save(profile);
+
             members.add(member);
         }
         memberRepository.saveAll(members);

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedServiceTest.java
@@ -3,10 +3,8 @@ package com.samsamhajo.deepground.feed.feed.service;
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
 import com.samsamhajo.deepground.feed.feed.exception.FeedException;
-import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
-import com.samsamhajo.deepground.feed.feed.model.FeedUpdateRequest;
-import com.samsamhajo.deepground.feed.feed.model.FetchFeedResponse;
-import com.samsamhajo.deepground.feed.feed.model.FetchFeedsResponse;
+import com.samsamhajo.deepground.feed.feed.model.*;
+import com.samsamhajo.deepground.feed.feed.repository.FeedLikeRepository;
 import com.samsamhajo.deepground.feed.feed.repository.FeedMediaRepository;
 import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
 import com.samsamhajo.deepground.feed.feedcomment.service.FeedCommentService;
@@ -18,7 +16,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.*;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
@@ -39,9 +40,15 @@ class FeedServiceTest {
     @Mock
     private FeedMediaRepository feedMediaRepository;
     @Mock
+    private FeedLikeRepository feedLikeRepository;
+    @Mock
     private FeedCommentService feedCommentService;
     @Mock
     private FeedLikeService feedLikeService;
+    @Mock
+    private RedisTemplate<String,Object> redisTemplate;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @InjectMocks
     private FeedService feedService;
@@ -71,6 +78,47 @@ class FeedServiceTest {
         assertThat(createdFeed.getMember().getId()).isEqualTo(testMember.getId());
 
         verify(feedMediaService).createFeedMedia(any(Feed.class), anyList());
+    }
+
+    @Test
+    @DisplayName("피드 생성 성공 - 이벤트 발행 확인")
+    void createFeedWithEventSuccess() {
+        // given
+        Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        FeedCreateRequest request = new FeedCreateRequest(TEST_CONTENT, List.of());
+        Feed expectedFeed = Feed.of(TEST_CONTENT, testMember);
+        when(feedRepository.save(any(Feed.class))).thenReturn(expectedFeed);
+
+        // when
+        feedService.createFeed(request, testMember);
+
+        // then
+        // 이벤트가 정확히 1번 발행되었는지 확인
+        verify(eventPublisher, times(1)).publishEvent(any(FeedCreateEvent.class));
+    }
+
+    @Test
+    @DisplayName("피드 목록 조회 성공 - Redis 캐시가 있는 경우 DB를 조회하지 않음")
+    void getFeedsFromRedisSuccess() {
+        // given
+        FetchFeedResponse cachedDto = new FetchFeedResponse();
+        cachedDto.setFeedId(100L);
+        cachedDto.setContent("캐시된 피드");
+
+        // redisTemplate.opsForList().range(...)가 데이터를 반환하도록 설정
+        ListOperations listOperations = mock(ListOperations.class);
+        when(redisTemplate.opsForList()).thenReturn(listOperations);
+        when(listOperations.range(anyString(), anyLong(), anyLong())).thenReturn(List.of(cachedDto));
+
+        // when
+        FetchFeedsResponse result = feedService.getFeeds(PageRequest.of(0, 10), 1L);
+
+        // then
+        assertThat(result.getFeeds()).hasSize(1);
+        assertThat(result.getFeeds().get(0).getContent()).isEqualTo("캐시된 피드");
+
+        // 핵심: DB 레포지토리는 호출되지 않아야 함!
+        verify(feedRepository, never()).findFeeds(any());
     }
 
     @Test
@@ -171,15 +219,20 @@ class FeedServiceTest {
     void deleteFeedSuccess() {
         // given
         Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
-        Feed existingFeed = Feed.of(TEST_CONTENT, testMember);
+        Feed existingFeed = spy(Feed.of(TEST_CONTENT, testMember));
+        Long feedId = 1L;
+        ReflectionTestUtils.setField(existingFeed, "id", feedId);
+
+        when(feedRepository.getById(feedId)).thenReturn(existingFeed);
 
         // when
         feedService.deleteFeed(existingFeed.getId());
 
         // then
+        verify(existingFeed).softDelete();
         verify(feedCommentService).deleteFeedCommentByFeed(existingFeed.getId());
         verify(feedLikeService).deleteAllByFeedId(existingFeed.getId());
         verify(feedMediaService).deleteAllByFeedId(existingFeed.getId());
-        verify(feedRepository).deleteById(existingFeed.getId());
+
     }
 }

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedServiceTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedServiceTest.java
@@ -64,6 +64,12 @@ class FeedServiceTest {
     void createFeedSuccess() {
         // given
         Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        MemberProfile testProfile = MemberProfile.create(
+                "image.png", testMember, "intro", "job", "company", "city", "edu",
+                new ArrayList<>(), "git", "link", "web", "twit"
+        );
+        ReflectionTestUtils.setField(testMember, "memberProfile", testProfile);
+
         FeedCreateRequest request = new FeedCreateRequest(TEST_CONTENT, List.of());
         Feed expectedFeed = Feed.of(TEST_CONTENT, testMember);
 
@@ -85,6 +91,11 @@ class FeedServiceTest {
     void createFeedWithEventSuccess() {
         // given
         Member testMember = Member.createLocalMember(TEST_EMAIL, TEST_PASSWORD, TEST_NICKNAME);
+        MemberProfile testProfile = MemberProfile.create(
+                "image.png", testMember, "intro", "job", "company", "city", "edu",
+                new ArrayList<>(), "git", "link", "web", "twit"
+        );
+        ReflectionTestUtils.setField(testMember, "memberProfile", testProfile);
         FeedCreateRequest request = new FeedCreateRequest(TEST_CONTENT, List.of());
         Feed expectedFeed = Feed.of(TEST_CONTENT, testMember);
         when(feedRepository.save(any(Feed.class))).thenReturn(expectedFeed);


### PR DESCRIPTION
## 📌 개요
- 피드 목록 조회 시 발생하는 db 부하를 줄이기 위해 `Redis` 를 활용해 최신 작성 피드 20개에 대한 `Look-Aside` 캐싱 전략을 도입했습니다
 
## 🛠️ 작업 내용
- [x] `Redis` 기반 최신 피드 20건 캐싱 로직 구
- [x] `FeedCreateEvent` DTO와 `FeedCacheHandler` 구현으로 캐시 갱신 로직 분리
- [x] 테스트 코드 작성
- [x] k6 부하 테스트 성능 검증 

### Redis 캐싱 및 이벤트 기반 아키텍쳐 도입
- 캐싱 전략: 조회 성능 최적화를 위해 자주 조회되는 1페이지(최신 20건) 데이터를 Redis List 자료구조에 저장합니다.
- 구조 개선:
    - 기존: `FeedService`가 피드 생성 후 직접 캐시를 갱신하거나 DB를 다시 조회함.
    - 변경: `FeedService`는 순수 데이터 객체인 `FeedCreateEvent`(DTO)만 발행하고, 실제 Redis 적재 로직은 `FeedCacheHandler`가 비동기적으로 처리하여 결합도를 낮췄습니다.

### 1000VUs 부하테스트 결과
- 테스트 환경: Docker Local / VUs 0 -> 1000 Ramping / Redis Look-Aside 적용
- 개선 요약: 사용자 체감 속도(Median)가 약 45% 단축되었으며, 시스템이 버틸 수 있는 부하 한계가 대폭 상승했습니다.

- DB 직접 조회
<img width="1167" height="650" alt="feedList 기존 코드 수치" src="https://github.com/user-attachments/assets/8e0fd65f-
ada4-43e1-9390-9d1d06245136" />
- Redis 캐싱 적용 
<img width="1188" height="677" alt="feedList redis 코드 수치" src="https://github.com/user-attachments/assets/1ac99f79-b0b7-44c2-8de6-27223357c805" />


구분 | DB 직접 조회 (Before) | Redis 캐싱 적용 (After) | 개선율
-- | -- | -- | --
Median Latency | 175ms | 97ms | ⚡ 1.8배 개선
P95 Latency | 818ms | 717ms | 약 12% 개선
Max Latency | 3.0s | 1.0s | 🛡️ 3배 방어 성공
 분석:동시 접속자 1,000명 도달 시 DB 방식은 커넥션 풀 고갈로 최대 3초 지연이 발생했으나,
Redis 도입 후 1초 이내로 방어하며 안정적인 서비스 유지를 했습니다

## 📌 차후 계획 (Optional)
- Redis나 DB 연결이 과도한 부하로 인해 장애 발생 시 즉각 알림 및 전체 서비스가 마비되지 않도록 파이프라인을 구축할 예정입니다.


## 📌 테스트 케이스
- [x] 기능 정상 동작 확인
- [x] 새로운 의존성 추가 여부 확인 (`package.json`, `build.gradle` 등)
- [x] 코드 스타일 및 컨벤션 준수 확인
- [x] 기존 테스트 통과 여부 확인

### 📌 기타 참고 사항
📌 리뷰어가 확인해야 할 추가 내용, 고민한 점, 결정 과정 등
-테스트 환경 제약 (Disclaimer): 해당 테스트는 단일 로컬 장비(Docker)에서 수행되어 로컬 리소스 경합으로 인해, `http_req_connecting`(연결 대기 시간)이 다소 높게 측정되었습니다.
---

#### 🙏🏻아래와 같이 PR을 리뷰해주세요.
- PR 내용이 부족하다면 보충 요청해주세요.
- 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
- 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
- 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
- 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feed creation updates a recent-feed cache and publishes events so new posts appear promptly.
  * Feed creation now returns cached feed data to the cache payload for faster serving.

* **Performance Improvements**
  * First page of feeds is served from Redis cache for faster initial loads.
  * Like-count synchronization improved to reduce stale like information.
  * Media upload now returns media URLs immediately after creation.

* **Tests**
  * Added/updated tests to verify Redis-backed caching and event publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->