### PR TITLE
[Fix] Redis 캐시 역직렬화 실패로 피드 목록 캐싱이 동작하지 않는 문제 수정

### DIFF
--- a/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
+++ b/src/main/java/com/samsamhajo/deepground/feed/feed/service/FeedService.java
@@ -1,5 +1,6 @@
 package com.samsamhajo.deepground.feed.feed.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.samsamhajo.deepground.feed.feed.entity.Feed;
 import com.samsamhajo.deepground.feed.feed.entity.FeedMedia;
 import com.samsamhajo.deepground.feed.feed.exception.FeedErrorCode;
@@ -41,6 +42,7 @@ public class FeedService {
     private final FeedLikeRepository feedLikeRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public Feed createFeed(FeedCreateRequest request, Member member) {
@@ -154,10 +156,10 @@ public class FeedService {
             }
 
             return cachedData.stream()
-                    .map(obj -> (FetchFeedResponse) obj)
+                    .map(obj -> objectMapper.convertValue(obj, FetchFeedResponse.class))
                     .toList();
         } catch (Exception e) {
-            log.error("Redis로부터 피드 캐시를 가져오는 중 에러 발생: {}",e.getMessage());
+            log.error("Redis로부터 피드 캐시를 가져오는 중 에러 발생", e);
             return List.of();
         }
     }

--- a/src/main/java/com/samsamhajo/deepground/global/config/RedisConfig.java
+++ b/src/main/java/com/samsamhajo/deepground/global/config/RedisConfig.java
@@ -17,16 +17,17 @@ public class RedisConfig {
             RedisConnectionFactory connectionFactory,
             ObjectMapper objectMapper
     ) {
-        objectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
-        objectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        ObjectMapper redisObjectMapper = objectMapper.copy();
+        redisObjectMapper.registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule());
+        redisObjectMapper.disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        redisObjectMapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
-        objectMapper.configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
-
         template.setKeySerializer(RedisSerializer.string());
         template.setValueSerializer(serializer);
-
         template.setHashKeySerializer(RedisSerializer.string());
         template.setHashValueSerializer(serializer);
 

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedCacheTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedCacheTest.java
@@ -1,0 +1,135 @@
+package com.samsamhajo.deepground.feed.feed.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.samsamhajo.deepground.feed.feed.model.FeedCreateRequest;
+import com.samsamhajo.deepground.feed.feed.model.FetchFeedResponse;
+import com.samsamhajo.deepground.feed.feed.model.FetchFeedsResponse;
+import com.samsamhajo.deepground.feed.feed.repository.FeedRepository;
+import com.samsamhajo.deepground.global.config.S3Config;
+import com.samsamhajo.deepground.global.upload.S3Uploader;
+import com.samsamhajo.deepground.member.entity.Member;
+import com.samsamhajo.deepground.member.entity.MemberProfile;
+import com.samsamhajo.deepground.member.entity.Role;
+import com.samsamhajo.deepground.member.repository.MemberRepository;
+import com.samsamhajo.deepground.member.repository.ProfileRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@SpringBootTest
+public class FeedCacheTest {
+
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+    @Autowired private ObjectMapper objectMapper;
+    @Autowired private FeedService feedService;
+    @Autowired private FeedRepository feedRepository;
+    @Autowired private MemberRepository memberRepository;
+    @Autowired private ProfileRepository profileRepository;
+
+    @MockBean protected S3Config s3Config;
+    @MockBean protected S3Uploader s3Uploader;
+
+    private static final String TEST_KEY = "feed:cache:test";
+    private static final String CACHE_KEY = "feed:recent:20";
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        redisTemplate.delete(TEST_KEY);
+        redisTemplate.delete(CACHE_KEY);
+        feedRepository.deleteAll();
+        memberRepository.deleteAll();
+
+        member = Member.createLocalMember("cache@test.com", "password123", "캐시테스터");
+        member.verify();
+        member.updateRole(Role.ROLE_USER);
+        memberRepository.save(member);
+
+        MemberProfile profile = MemberProfile.create(
+                "image.png", member, "intro", "job", "company", "city", "edu",
+                new ArrayList<>(), "git", "link", "web", "twit"
+        );
+        profileRepository.save(profile);
+    }
+
+    @AfterEach
+    void tearDown() {
+        redisTemplate.delete(TEST_KEY);
+        redisTemplate.delete(CACHE_KEY);
+        feedRepository.deleteAll();
+        memberRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("FetchFeedResponse - Redis 저장 후 objectMapper.convertValue()로 역직렬화 성공")
+    void redisCacheSerializationTest() {
+        // given
+        FetchFeedResponse response = new FetchFeedResponse();
+        response.setFeedId(1L);
+        response.setContent("테스트 피드");
+        response.setMemberName("테스터");
+        response.setPublicId(UUID.randomUUID());
+        response.setCreatedAt(LocalDateTime.now());
+        response.setMediaUrls(List.of("http://example.com/image.jpg"));
+
+        // when - Redis에 쓰기
+        redisTemplate.opsForList().leftPush(TEST_KEY, response);
+
+        // then - Redis에서 읽어 convertValue()로 변환 (FeedService.fetchFromRedis() 동일 방식)
+        List<Object> cached = redisTemplate.opsForList().range(TEST_KEY, 0, -1);
+        assertThat(cached).isNotNull().hasSize(1);
+
+        Object rawValue = cached.get(0);
+        assertThatCode(() -> {
+            FetchFeedResponse result = objectMapper.convertValue(rawValue, FetchFeedResponse.class);
+            assertThat(result.getFeedId()).isEqualTo(1L);
+            assertThat(result.getContent()).isEqualTo("테스트 피드");
+            assertThat(result.getMemberName()).isEqualTo("테스터");
+        }).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("피드 생성 시 feed:recent:20 Redis 키에 캐시 적재")
+    void feedCreateCachesInRedis() {
+        // when
+        feedService.createFeed(new FeedCreateRequest("Redis 캐시 테스트 피드", List.of()), member);
+
+        // then - 트랜잭션 커밋 후 @TransactionalEventListener 실행 대기
+        Long size = redisTemplate.opsForList().size(CACHE_KEY);
+        assertThat(size).isGreaterThan(0);
+
+        List<Object> cached = redisTemplate.opsForList().range(CACHE_KEY, 0, -1);
+        FetchFeedResponse cachedFeed = objectMapper.convertValue(cached.get(0), FetchFeedResponse.class);
+        assertThat(cachedFeed.getContent()).isEqualTo("Redis 캐시 테스트 피드");
+    }
+
+    @Test
+    @DisplayName("피드 목록 첫 페이지 조회 시 Redis 캐시에서 응답")
+    void getFeedsReadsFromRedis() {
+        // given - 피드 생성으로 Redis 캐시 적재
+        feedService.createFeed(new FeedCreateRequest("캐시 조회 테스트 피드", List.of()), member);
+        assertThat(redisTemplate.opsForList().size(CACHE_KEY)).isGreaterThan(0);
+
+        // when - 첫 페이지 조회
+        FetchFeedsResponse response = feedService.getFeeds(PageRequest.of(0, 20), null);
+
+        // then - Redis 캐시 데이터로 응답
+        assertThat(response.getFeeds()).isNotEmpty();
+        assertThat(response.getFeeds().get(0).getContent()).isEqualTo("캐시 조회 테스트 피드");
+    }
+}

--- a/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedCacheTest.java
+++ b/src/test/java/com/samsamhajo/deepground/feed/feed/service/FeedCacheTest.java
@@ -125,10 +125,13 @@ public class FeedCacheTest {
         feedService.createFeed(new FeedCreateRequest("캐시 조회 테스트 피드", List.of()), member);
         assertThat(redisTemplate.opsForList().size(CACHE_KEY)).isGreaterThan(0);
 
+        // DB에서 피드 삭제 - Redis에만 데이터가 남아있는 상태 강제
+        feedRepository.deleteAll();
+
         // when - 첫 페이지 조회
         FetchFeedsResponse response = feedService.getFeeds(PageRequest.of(0, 20), null);
 
-        // then - Redis 캐시 데이터로 응답
+        // then - DB가 아닌 Redis 캐시 데이터로 응답
         assertThat(response.getFeeds()).isNotEmpty();
         assertThat(response.getFeeds().get(0).getContent()).isEqualTo("캐시 조회 테스트 피드");
     }


### PR DESCRIPTION
📌 개요
- RedisConfig에서 GenericJackson2JsonRedisSerializer에 커스텀 ObjectMapper를 주입할 때 @class 타입
  정보가 JSON에 포함되지 않아, fetchFromRedis() 에서 역직렬화 시 LinkedHashMap으로 반환되어
  ClassCastException이 발생했습니다. 해당 예외가 catch 블록에 조용히 삼켜져 캐시가 있어도 항상 DB를
  조회하는 상태로 동작하고 있었습니다.

📌 작업 내용
- `RedisConfig` 에서 ` ObjectMapper`를 `copy()`로 복사하여 공유 빈 직접 변형 방지
- `FeedService` 의  `fetchFromRedis()`에서 직접 캐스팅 대신 `objectMapper.convertValue()` 사용으로 역직렬화
  방식 변경
 - `FeedService`  에러 로그에 스택 트레이스 포함하도록 수정 (`e.getMessage() → e`)
 - 테스트 코드 작성

  📌 테스트
`FeedCacheTest` - 3가지 시나리오 검증
1. 직렬화/역직렬화 검증 (`redisCacheSerializationTest`)
  `FetchFeedResponse`를 Redis에 저장 후 `objectMapper.convertValue()`로 읽어올 때 정상 복원되는지 확인
2. 캐시 적재 검증 (`feedCreateCachesInRedis`)
  피드 생성 → `@TransactionalEventListener` → `FeedCacheHandler` → `feed:recent:20` 키 적재 여부 확인
3. 캐시 조회 검증 (`getFeedsReadsFromRedis`)
  첫 페이지 조회 시 Redis에 적재된 데이터로 응답하는지 확인
 
🙏🏻아래와 같이 PR을 리뷰해주세요.
 - PR 내용이 부족하다면 보충 요청해주세요.
 - 코드 스타일이 팀의 규칙에 맞게 작성되었는지, 일관성을 유지하고 있는지 확인해주세요.
 - 코드에 대한 문서화나 주석이 필요한 부분에 적절하게 작성되어 있는지 확인해주세요.
 - 구현된 로직이 효율적이고 올바르게 작성되었는지, 아키텍처를 잘 준수하고 있는지 검토해주세요.
 - 네이밍, 포매팅, 주석 등 코드의 일관성이 유지되고 있는지 확인해주세요

close #11 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feed caching reliability via safer serialization/deserialization and more robust Redis handling.
  * Enhanced error logging around cache retrieval for clearer diagnostics.

* **Tests**
  * Added comprehensive tests covering Redis serialization, caching on feed creation, and Redis-backed feed retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->